### PR TITLE
Changement de terminologie

### DIFF
--- a/basics/templates.md
+++ b/basics/templates.md
@@ -1,6 +1,6 @@
-# Schémas (templates)
+# Modèles ou patrons (templates)
 
-**D** permet la définition de schémas de fonctions similaires à C++ ou Java, ce qui veut signifie la définition de fonctions ou d'objets **génériques** qui ne fonctionnent avec n'importe quel type pour lequel les instructions contenues dans le corps de la fonction compilent sans erreurs:
+**D** permet la définition de modèles de fonctions similaires à C++ ou Java, ce qui est un moyen de définir des fonctions ou des objets **génériques** qui fonctionnent avec n'importe quel type pour lequel les instructions contenues dans le corps de la fonction compilent sans erreurs:
 
 ```d
 auto add(T)(T lhs, T rhs)
@@ -9,7 +9,7 @@ auto add(T)(T lhs, T rhs)
 }
 ```
 
-Le paramètre de schéma `T` est défini entre parenthèses avant la liste des paramètres de la fonction. `T` est un emplacement de type, qui sera remplacé par le compilateur quand la fonction sera *instanciée* en utilisant l'opérateur `!`:
+Le paramètre de modèle `T` est défini entre parenthèses avant la liste des paramètres de la fonction. `T` est un paramètre de substitution, qui sera remplacé par le compilateur quand la fonction sera *instanciée* en utilisant l'opérateur `!`:
 
 ```d
 add!int(5,10);
@@ -17,10 +17,10 @@ add!float(5.0f, 10.0f);
 add!Animal(Chien,chat); // ne compilera pas, Animal n'implémente pas l'opérateur +
 ```
 
-### Déductions de paramètres de schémas
+### Déductions de paramètres de modèles
 
-Les schémas de fonctions ont deux listes de paramètres, la première pour les paramètres à la compilation et la deuxième pour les paramètres à l'exécution. (Les fonctions schématisées ne peuvent accepter que des paramètres à l'exécution).
-Si un ou plusieurs paramètres de compilation ne sont pas fournis lorsque la fonction est appellée, le compilateur essaye de les déduire à partir de la liste des paramètres d'exécution et de leurs types:
+Les modèles de fonctions ont deux listes de paramètres, la première pour les paramètres à la compilation et la deuxième pour les paramètres à l'exécution. (Les fonctions sans patron ne peuvent accepter que des paramètres à l'exécution).
+Si un ou plusieurs paramètres de substitution ne sont pas fournis lorsque la fonction est appelée, le compilateur essaye de les déduire à partir des types des paramètres d'exécution:
 
 ```d
 int a = 5; int b = 10;
@@ -29,13 +29,13 @@ float c = 5.0;
 add(a, c); // On déduit que `T` est un `float`
 ```
 
-### Propriétés des schémas
+### Propriétés des modèles
 
-Une fonction peut avoir un nombre arbitraire de paramètres de schéma qui sont spécifiés à l'instanciation en utilisant la syntaxe `fonction!(T1, T2 ...)`. Les paramètres de schéma peuvent être n'importe quel type, y compris des `string`s et des nombres à virgule flottante.
+Une fonction peut avoir un nombre arbitraire de paramètres de substitution qui sont spécifiés à l'instanciation en utilisant la syntaxe `fonction!(T1, T2 ...)`. Les paramètres de substitution peuvent être de n'importe quel type de base, y compris des `string`s et des nombres à virgule flottante.
 
-Contrairement aux génériques en Java, les schémas en D ne fonctionnent qu'à la compilation, et génèrent du code optimisé et taillé sur mesure pour l'ensemble de types sur lesquels la fonction est appellée.
+Contrairement aux génériques en Java, les modèles en D ne fonctionnent qu'à la compilation, et génèrent du code optimisé et taillé sur mesure pour l'ensemble de types sur lesquels la fonction est appellée.
 
-Bien sur, on peut définir des schémas de `struct`, de `class` et d'`interface` également:
+Bien sûr, on peut également définir des patrons à partir de `struct`, de `class` et d'`interface`:
 
 ```d
 struct S(T)
@@ -46,14 +46,14 @@ struct S(T)
 
 ### Pour aller plus loin
 
-- [Tutoriel sur les schémas en D](https://github.com/PhilippeSigaud/D-templates-tutorial)
-- [Schémas dans _Programming in D_](http://ddili.org/ders/d.en/templates.html)
+- [Tutoriel sur les modèles en D](https://github.com/PhilippeSigaud/D-templates-tutorial)
+- [Modèles dans _Programming in D_](http://ddili.org/ders/d.en/templates.html)
 
 #### Ressources avancées
 
 - [Spécifichation des schémas en D](https://dlang.org/spec/template.html)
-- [Les schémas en D](http://dlang.org/templates-revisited.html):  Walter Bright écrit à propos de comment D améliore les templates C++.
-- [Schémas variadiques](http://dlang.org/variadic-function-templates.html): Articles à propos d'un idiome D qui permet d'implémenter des fonctions variadiques à l'aide de schémas variadiques
+- [Les modèles en D](http://dlang.org/templates-revisited.html):  Walter Bright écrit à propos de comment D améliore les templates C++.
+- [Modèles variadiques](http://dlang.org/variadic-function-templates.html): Articles à propos d'un idiome D qui permet d'implémenter des fonctions variadiques à l'aide de modèles variadiques
 
 ## {SourceCode}
 
@@ -61,8 +61,8 @@ struct S(T)
 import std.stdio : writeln;
 
 /*
-Schéma de classe qui permet
-un implémentation générique
+Modèle de classe qui permet
+une implémentation générique
 des animaux
 */
 class Animal(string bruit) {
@@ -80,7 +80,7 @@ class Chat: Animal!("Miaou") {
 // alias Chat = Animal!("Miaou");
 
 /**
-Schéma de fonction qui prend un type
+Modèle de fonction qui prend un type
 T et implémente la fonction faireBruit
 Params:
     animal = objet qui peut faire du bruit

--- a/basics/templates.md
+++ b/basics/templates.md
@@ -33,7 +33,7 @@ add(a, c); // On déduit que `T` est un `float`
 
 Une fonction peut avoir un nombre arbitraire de paramètres de substitution qui sont spécifiés à l'instanciation en utilisant la syntaxe `fonction!(T1, T2 ...)`. Les paramètres de substitution peuvent être de n'importe quel type de base, y compris des `string`s et des nombres à virgule flottante.
 
-Contrairement aux génériques en Java, les modèles en D ne fonctionnent qu'à la compilation, et génèrent du code optimisé et taillé sur mesure pour l'ensemble de types sur lesquels la fonction est appellée.
+Contrairement aux génériques en Java, les modèles en D ne fonctionnent qu'à la compilation, et génèrent du code optimisé et taillé sur mesure pour l'ensemble de types sur lesquels la fonction est appelée.
 
 Bien sûr, on peut également définir des patrons à partir de `struct`, de `class` et d'`interface`:
 


### PR DESCRIPTION
Je ne pense pas que modèle soit la bonne traduction pour template. J'ai cherché un peu sur Internet et je n'ai pas réussi à trouver d'exemples de ce terme pour désigner les templates. D'après [wikipedia] la traduction en serait modèles ou patron. Comme patron est déjà utilisé pour les patrons de conception (design pattern), j'ai préféré choisir "modèle". 
J'ai aussi inventé une terminologie que vous pourrez rejeter si vous voulez. Je trouve que "variable ou paramètre de substitution" sonne bien pour remplacer "placeholder" ou "template parameter". Je ne l'ai jamais vu nul part (vu que je lis très peu de textes techniques en français) mais je trouve que celà exprime bien le mecanisme. À vous de choisir :-)
J'ai aussi corrigé les quelques fautes d'orthographes que j'ai trouvé.

[wikipedia]: (https://fr.wikipedia.org/wiki/Template_(programmation))