### PR TITLE
Full source code + changing formulations

### DIFF
--- a/welcome/welcome-to-d.md
+++ b/welcome/welcome-to-d.md
@@ -10,7 +10,7 @@ Cette visite donne un aperçu de ce langage __puissant__ et __expressif__ qui se
 
 ### Qu'est-ce que le langage D ?
 
-Le D est le résultat de _décennies d'expérience dans la conception de compilateurs_ pour de nombreux langages, et c'est un langage aux [fonctionnalités uniques](http://dlang.org/overview.html): 
+Le D est le résultat de _décennies d'expérience dans la conception de compilateurs_ pour de nombreux langages, et c'est un langage aux [fonctionnalités uniques](http://dlang.org/overview.html):
 
 {{#dmandesktop}}
 
@@ -49,19 +49,20 @@ import std.range;
 void main()
 {
     // Commençons !
-    writeln("Hello World!");
+    writeln("Bonjour tout le monde !");
 
-    // Un exemple pour programmeurs expérimentés :
-    // Prend trois listes, et sans allouer
-    // de nouvelle mémoire, effectue un tri
-    // traversant les listes existantes
+    // Un exemple pour programmeurs
+    // expérimentés : prend trois listes,
+    // et sans allouer de nouvelle mémoire,
+    // effectue un tri traversant les listes
+    // existantes
     int[] arr1 = [4, 9, 7];
     int[] arr2 = [5, 2, 1, 10];
     int[] arr3 = [6, 8, 3];
     sort(chain(arr1, arr2, arr3));
     writefln("%s\n%s\n%s\n", arr1, arr2, arr3);
-    // Pour en apprendre plus sur cet exemple, voir
-    // la page "Algorithmes de range" dans le menu
-    // "Quelques bouchées de D"
+    // Pour en apprendre plus sur cet exemple,
+    // voir la page "Algorithmes de range" dans
+    // le menu "Quelques bouchées de D"
 }
 ```

--- a/welcome/welcome-to-d.md
+++ b/welcome/welcome-to-d.md
@@ -43,10 +43,25 @@ Cette visite est [open-source](https://github.com/dlang-tour) et nous accueillon
 
 ```d
 import std.stdio;
+import std.algorithm;
+import std.range;
 
-// Allons-y !
 void main()
 {
-    writeln("Bonjour tout le monde !");
+    // Commençons !
+    writeln("Hello World!");
+
+    // Un exemple pour programmeurs expérimentés :
+    // Prend trois listes, et sans allouer
+    // de nouvelle mémoire, effectue un tri
+    // traversant les listes existantes
+    int[] arr1 = [4, 9, 7];
+    int[] arr2 = [5, 2, 1, 10];
+    int[] arr3 = [6, 8, 3];
+    sort(chain(arr1, arr2, arr3));
+    writefln("%s\n%s\n%s\n", arr1, arr2, arr3);
+    // Pour en apprendre plus sur cet exemple, voir
+    // la page "Algorithmes de range" dans le menu
+    // "Quelques bouchées de D"
 }
 ```

--- a/welcome/welcome-to-d.md
+++ b/welcome/welcome-to-d.md
@@ -4,7 +4,7 @@ Bienvenue dans cette visite interactive du *langage de programmation D*
 
 {{#dmanmobile}}
 
-Cette visite va vous donner un aperçu de ce langage __puissant__ et __expressif__ qui se compile vers du code __natif__ et __performant__.
+Cette visite donne un aperçu de ce langage __puissant__ et __expressif__ qui se compile directement vers du code machine __natif__ et __performant__.
 
 {{/dmanmobile}}
 
@@ -17,14 +17,14 @@ Le D est le résultat de _décennies d'expérience dans la conception de compila
 - des constructions _haut niveau_ pour des modélisations puissantes
 - un langage _compilé_ et _performant_
 - typage statique
-- amélioration du C++ (sans les erreurs)
 - interfacage direct avec l'API du système d'exploitation et le matériel
-- compilation très rapide
+- temps de compilation extrèmement rapide
 - permet une gestion sûre de la mémoire (SafeD)
 - du code _maintenable_ et _lisible_
 - une courbe d'apprentissage courte (syntaxe similiare au C, à Java et à d'autres)
-- interfaçable avec des librairies C
-- multi-paradigme (impératif, structuré, orienté objet, générique, fonctionnel et même assembleur)
+- compatible avec l'interface binaire-programme C
+- compatibilité limitée avec l'interface binaire-programme C++
+- multi-paradigme (impératif, structuré, orienté objet, générique, fonctionnel pur et même assembleur)
 - prévention des erreurs intégrée (contrats, tests unitaires)
 
 ... et beaucoup d'autres [fonctionnalités](http://dlang.org/overview.html)
@@ -33,8 +33,7 @@ Le D est le résultat de _décennies d'expérience dans la conception de compila
 
 ### À propos de cette visite
 
-Chaque partie est accompagnée d'exemples. Ces exemples peuvent être modifiés et seront recompilés automatiquement. Ainsi vous pourrez faire votre propre expérience du D.
-Cliquez sur le bouton "run" (ou appuyez sur `Ctrl+Entrée`) pour exécuter le code.
+Chaque partie est accompagnée d'exemples. Ces exemples peuvent être modifiés et utilisés pour expérimenter avec les fonctionnalités du langage D. Cliquez sur le bouton "Executer" (ou appuyez sur `Ctrl+Entrée`) pour exécuter le code.
 
 ### Contribuer
 


### PR DESCRIPTION
The french "Welcome to D" page doesn't use the same source code as the english one. There is no reason for this to happen.

Also spotted a few mistakes (it is said nowhere that D is an improvement of C++ without errors, yet the french version says "amélioration du C++ (sans les erreurs)") and reformulated a few sentences to fit better with the english text.